### PR TITLE
packageDependencies support raw url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,16 @@ Pkgm.prototype.loadAll = function(folder) {
 Pkgm.prototype.uriInfos = function(uri) {
     var parts = uri.split("#");
     var version = parts[1];
-    uri = url.resolve('https://github.com', parts[0]);
+    var gitPrefix = "git@";
+    var httpsPrefix = "https://";
+    var httpPrefix = "http://";
+    if ( util.startsWith(parts[0], gitPrefix) ||
+         util.startsWith(parts[0], httpsPrefix) ||
+         util.startsWith(parts[0], httpPrefix) ) {
+      uri = parts[0];
+    } else {
+      uri = url.resolve('https://github.com', parts[0]);
+    }
 
     return {
         uri: uri,

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,9 +107,9 @@ Pkgm.prototype.uriInfos = function(uri) {
     var gitPrefix = "git@";
     var httpsPrefix = "https://";
     var httpPrefix = "http://";
-    if ( util.startsWith(parts[0], gitPrefix) ||
-         util.startsWith(parts[0], httpsPrefix) ||
-         util.startsWith(parts[0], httpPrefix) ) {
+    if ( utils.startsWith(parts[0], gitPrefix) ||
+         utils.startsWith(parts[0], httpsPrefix) ||
+         utils.startsWith(parts[0], httpPrefix) ) {
       uri = parts[0];
     } else {
       uri = url.resolve('https://github.com', parts[0]);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,5 +70,6 @@ var execFile = simpleExecBuilder(cp.execFile);
 module.exports = {
     exec: exec,
     execFile: execFile,
-    deepkeys: deepkeys
+    deepkeys: deepkeys,
+    startsWith: startsWith
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,10 @@ var Q = require('q');
 var _ = require('lodash');
 var cp = require('child_process');
 
+// Is string has prefix
+function startsWith(string, prefix) {
+  return string.slice(0, prefix.length) == prefix;
+}
 
 // Generate callbacks for exec functions
 function _execHandler(command, deffered) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "pkgm",
     "main": "lib/index.js",
     "description": "Make it easy to build a package manager for client/node large applications",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "author": "Samy Pesse <samypesse@gmail.com>",
     "repository": {
         "type": "git",


### PR DESCRIPTION
We company have built a private git repository, so we want add private packageDependencies in `package.json`

Usage:

```
"packageDependencies": {
        "about": "CodeboxIDE/package-about",
        "command-palette": "CodeboxIDE/package-command-palette",
        "myPackage": "git@gitlab.domain.com:hongweiyi/package-myPackage.git"
}
```
